### PR TITLE
bug fix : compute_openclip_text_embeddings.py

### DIFF
--- a/compute_openclip_text_embeddings.py
+++ b/compute_openclip_text_embeddings.py
@@ -30,6 +30,7 @@ if __name__ == "__main__":
     parser.add_argument("text_prompts_file", type=str)
     parser.add_argument("output_path", type=str)
     parser.add_argument("--model_name", type=str, default="ViT-B-32")
+    parser.add_argument("--pretrained", type=str, default="laion2b_s34b_b79k")
     args = parser.parse_args()
 
     with open(args.text_prompts_file, 'r') as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+open_clip_torch


### PR DESCRIPTION
Added missing 'pretrained' parameter to the compute_openclip_text_embeddings.py file.